### PR TITLE
Fix iOS Safari animation artifacts on SVG logo

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -160,7 +160,7 @@ export default function Hero() {
             <motion.div
               ref={targetRef}
               className="relative h-full shrink-0 overflow-visible"
-              style={{ aspectRatio: "604/440" }}
+              style={{ aspectRatio: "604/440", willChange: "transform", backfaceVisibility: "hidden" }}
               animate={containerControls}
             >
               {mounted && (

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -160,7 +160,7 @@ export default function Hero() {
             <motion.div
               ref={targetRef}
               className="relative h-full shrink-0 overflow-visible"
-              style={{ aspectRatio: "604/440", willChange: "transform", backfaceVisibility: "hidden" }}
+              style={{ aspectRatio: "604/440", backfaceVisibility: "hidden" }}
               animate={containerControls}
             >
               {mounted && (

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -160,7 +160,7 @@ export default function Hero() {
             <motion.div
               ref={targetRef}
               className="relative h-full shrink-0 overflow-visible"
-              style={{ aspectRatio: "604/440", backfaceVisibility: "hidden" }}
+              style={{ aspectRatio: "604/440" }}
               animate={containerControls}
             >
               {mounted && (

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -31,41 +31,54 @@ export default function Logo({
       xmlns="http://www.w3.org/2000/svg"
       className={className}
     >
+      <defs>
+        <clipPath id="logo-bar-clip">
+          <motion.rect
+            x="-24"
+            y="0"
+            height="440"
+            initial={{ width: 0 }}
+            animate={{ width: 628 }}
+            transition={{
+              duration: 0.5,
+              delay: 0.15,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+          />
+        </clipPath>
+      </defs>
       <g fill="currentColor">
         <motion.path
           d="m506 0h-88.158l-246.842 440h88.158z"
-          initial={{ opacity: 0, x: -30, scaleY: 0.7 }}
-          animate={{ opacity: 1, x: 0, scaleY: 1 }}
+          initial={{ opacity: 0, x: -30 }}
+          animate={{ opacity: 1, x: 0 }}
           transition={{
             duration: 0.6,
             delay: 0.0,
             ease: [0.22, 1, 0.36, 1],
           }}
-          style={{ transformOrigin: "center center", backfaceVisibility: "hidden" }}
         />
         <motion.path
           d="m0 260 50.967-60h505.033l-50.967 60z"
-          initial={{ opacity: 0, scaleX: 0 }}
-          animate={{ opacity: 1, scaleX: 1 }}
+          clipPath="url(#logo-bar-clip)"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
           transition={{
-            duration: 0.5,
+            duration: 0.3,
             delay: 0.15,
             ease: [0.22, 1, 0.36, 1],
           }}
-          style={{ transformOrigin: "left center", backfaceVisibility: "hidden" }}
         />
         <motion.circle
           cx="496"
           cy="135"
-          r="35"
-          initial={{ opacity: 0, scale: 0 }}
-          animate={{ opacity: 1, scale: 1 }}
+          initial={{ opacity: 0, r: 0 }}
+          animate={{ opacity: 1, r: 35 }}
           transition={{
             duration: 0.4,
             delay: 0.4,
             ease: [0.34, 1.56, 0.64, 1],
           }}
-          style={{ transformOrigin: "496px 135px", backfaceVisibility: "hidden" }}
         />
       </g>
     </svg>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -41,7 +41,7 @@ export default function Logo({
             delay: 0.0,
             ease: [0.22, 1, 0.36, 1],
           }}
-          style={{ transformOrigin: "center center" }}
+          style={{ transformOrigin: "center center", willChange: "transform", backfaceVisibility: "hidden" }}
         />
         <motion.path
           d="m0 260 50.967-60h505.033l-50.967 60z"
@@ -52,7 +52,7 @@ export default function Logo({
             delay: 0.15,
             ease: [0.22, 1, 0.36, 1],
           }}
-          style={{ transformOrigin: "left center" }}
+          style={{ transformOrigin: "left center", willChange: "transform", backfaceVisibility: "hidden" }}
         />
         <motion.circle
           cx="496"
@@ -65,7 +65,7 @@ export default function Logo({
             delay: 0.4,
             ease: [0.34, 1.56, 0.64, 1],
           }}
-          style={{ transformOrigin: "496px 135px" }}
+          style={{ transformOrigin: "496px 135px", willChange: "transform", backfaceVisibility: "hidden" }}
         />
       </g>
     </svg>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { useState } from "react";
 
 export default function Logo({
   className,
@@ -24,6 +25,13 @@ export default function Logo({
     );
   }
 
+  return <AnimatedLogo className={className} />;
+}
+
+function AnimatedLogo({ className }: { className?: string }) {
+  const [done, setDone] = useState(false);
+  const gpu = done ? undefined : ("transform" as const);
+
   return (
     <svg
       fill="none"
@@ -31,54 +39,42 @@ export default function Logo({
       xmlns="http://www.w3.org/2000/svg"
       className={className}
     >
-      <defs>
-        <clipPath id="logo-bar-clip">
-          <motion.rect
-            x="-24"
-            y="0"
-            height="440"
-            initial={{ width: 0 }}
-            animate={{ width: 628 }}
-            transition={{
-              duration: 0.5,
-              delay: 0.15,
-              ease: [0.22, 1, 0.36, 1],
-            }}
-          />
-        </clipPath>
-      </defs>
       <g fill="currentColor">
         <motion.path
           d="m506 0h-88.158l-246.842 440h88.158z"
-          initial={{ opacity: 0, x: -30 }}
-          animate={{ opacity: 1, x: 0 }}
+          initial={{ opacity: 0, x: -30, scaleY: 0.7 }}
+          animate={{ opacity: 1, x: 0, scaleY: 1 }}
           transition={{
             duration: 0.6,
             delay: 0.0,
             ease: [0.22, 1, 0.36, 1],
           }}
+          style={{ transformOrigin: "center center", willChange: gpu }}
         />
         <motion.path
           d="m0 260 50.967-60h505.033l-50.967 60z"
-          clipPath="url(#logo-bar-clip)"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
+          initial={{ opacity: 0, scaleX: 0 }}
+          animate={{ opacity: 1, scaleX: 1 }}
           transition={{
-            duration: 0.3,
+            duration: 0.5,
             delay: 0.15,
             ease: [0.22, 1, 0.36, 1],
           }}
+          style={{ transformOrigin: "left center", willChange: gpu }}
         />
         <motion.circle
           cx="496"
           cy="135"
-          initial={{ opacity: 0, r: 0 }}
-          animate={{ opacity: 1, r: 35 }}
+          r="35"
+          initial={{ opacity: 0, scale: 0 }}
+          animate={{ opacity: 1, scale: 1 }}
           transition={{
             duration: 0.4,
             delay: 0.4,
             ease: [0.34, 1.56, 0.64, 1],
           }}
+          style={{ transformOrigin: "496px 135px", willChange: gpu }}
+          onAnimationComplete={() => setDone(true)}
         />
       </g>
     </svg>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -41,7 +41,7 @@ export default function Logo({
             delay: 0.0,
             ease: [0.22, 1, 0.36, 1],
           }}
-          style={{ transformOrigin: "center center", willChange: "transform", backfaceVisibility: "hidden" }}
+          style={{ transformOrigin: "center center", backfaceVisibility: "hidden" }}
         />
         <motion.path
           d="m0 260 50.967-60h505.033l-50.967 60z"
@@ -52,7 +52,7 @@ export default function Logo({
             delay: 0.15,
             ease: [0.22, 1, 0.36, 1],
           }}
-          style={{ transformOrigin: "left center", willChange: "transform", backfaceVisibility: "hidden" }}
+          style={{ transformOrigin: "left center", backfaceVisibility: "hidden" }}
         />
         <motion.circle
           cx="496"
@@ -65,7 +65,7 @@ export default function Logo({
             delay: 0.4,
             ease: [0.34, 1.56, 0.64, 1],
           }}
-          style={{ transformOrigin: "496px 135px", willChange: "transform", backfaceVisibility: "hidden" }}
+          style={{ transformOrigin: "496px 135px", backfaceVisibility: "hidden" }}
         />
       </g>
     </svg>


### PR DESCRIPTION
Force GPU compositing on animated SVG elements with willChange and
backfaceVisibility to prevent WebKit from leaving ghost lines during
scaleX/scaleY/scale transform animations.

https://claude.ai/code/session_01Tzsuk5enZvkDzR2E2xL1oy